### PR TITLE
Fixed the HTML related open issue present at the bottom of the readme

### DIFF
--- a/html_editor.js
+++ b/html_editor.js
@@ -38,6 +38,9 @@ module.exports = class HTMLEditor {
 
             /* If the type attribute is set it should be valid for JS */
             var scriptType = cScriptElement.attribs["type"];
+            if(scriptType != undefined) {
+                scriptType = scriptType.toLowerCase();
+            }
             if (scriptType && !VALID_JS_TYPES.includes(scriptType)) { return; }
 
             /* Assume the script is hosted on same server */
@@ -104,6 +107,9 @@ module.exports = class HTMLEditor {
 
             /* If the type attribute is set it should be valid for JS */
             var scriptType = cScriptElement.attribs["type"];
+            if(scriptType != undefined) {
+                scriptType = scriptType.toLowerCase();
+            }
             if (scriptType && !VALID_JS_TYPES.includes(scriptType)) return;
 
             var scriptSrc = cScriptElement.attribs["src"];
@@ -156,6 +162,9 @@ module.exports = class HTMLEditor {
 
             /* If the type attribute is set it should be valid for JS */
             var scriptType = cScriptElement.attribs["type"];
+            if(scriptType != undefined) {
+                scriptType = scriptType.toLowerCase();
+            }
             if (scriptType && !VALID_JS_TYPES.includes(scriptType)) { return; }
             
             // Add a unique id to each script element

--- a/html_editor.js
+++ b/html_editor.js
@@ -20,7 +20,8 @@ module.exports = class HTMLEditor {
     loadFile(filePath) {
         this.filePath = filePath; /* relative to pwd */
         this.source = this.originalSource = fs.readFileSync(filePath).toString();
-        this.html = this.originalHtml = cheerio.load(this.source);
+        const $ = cheerio.load(this.source);
+        this.html = this.originalHtml = $;
         return this;
     }
 
@@ -82,11 +83,11 @@ module.exports = class HTMLEditor {
      * The index function may fail when there are weird linebreaks
      */
     updateCode(oldCode, newCode) {
-        var index = this.source.indexOf(oldCode); 
-        if (index < 0) {
+        if (oldCode.length < 0) {
             return logger.error(`[html_editor] cannot update code: '${oldCode}' not found`);
         }
-        this.source = this.source.splice(index, oldCode.length, newCode);
+        oldCode.replaceWith(newCode)
+        this.source = this.html.html();
     }
 
     saveFile() {
@@ -147,7 +148,7 @@ module.exports = class HTMLEditor {
     /**
      * Exports all internal JS scrips to their own file
      */
-    exportInternalScripts(directory) {
+    exportInternalScripts(directory, entryFile) {
         var cScripts = this.html('script');
 
         cScripts.each((index, cScriptElement) => {
@@ -157,8 +158,11 @@ module.exports = class HTMLEditor {
             var scriptType = cScriptElement.attribs["type"];
             if (scriptType && !VALID_JS_TYPES.includes(scriptType)) { return; }
             
+            // Add a unique id to each script element
+            this.html(cScriptElement).attr('id', `script_${index}`);
+
             /* Store the inline script into a local file */
-            var inlineScriptContent = cheerio(cScriptElement).html();
+            var inlineScriptContent = this.html(cScriptElement).html();
             var randomFileName = "exported_" + getRandomFilename(6) + ".js";
             var relativeFilePath = path.join(lacunaSettings.LACUNA_OUTPUT_DIR, randomFileName); /* relative to the project */
             var filePath = path.join(directory, relativeFilePath); /* relative to pwd */
@@ -166,13 +170,17 @@ module.exports = class HTMLEditor {
 
             /* Since the lacuna_cache resides at the framework directory level, references should take it into account */
             var relativePathDifference = path.relative(directory, entryFile);
+
             var numberOfNestedDirectories = relativePathDifference.split("/").length - 1; // counts the number of directories between the directory and the entry file
-            var relDirFix = "../".repeat(numberOfNestedDirectories);
+
+            // var relDirFix = "../".repeat(numberOfNestedDirectories);
+            var relDirFix = "./"
 
             /* Update the reference */
             var oldReference = this.html.html(cScriptElement);
+            var scriptElementToBeReplaced = this.html(`#script_${index}`)
             var newReference = `<script src="${path.join(relDirFix, relativeFilePath)}"></script>`;
-            this.updateCode(oldReference, newReference);
+            this.updateCode(scriptElementToBeReplaced, newReference);
             this.saveFile();
 
 


### PR DESCRIPTION
Fixed the HTML related open issue present at the bottom of the readme of the Lacuna tool. Now onwards, there won't be any issues in the identification of  scripts within HTML even on the presence of spaces/line breaks in HTML

- Added functionality to convert script type to lower case, since in HTML the script type is case-insensitive. Therefore, if a HTML file had script type in uppercase the script identification just fails. Henceforth this issue will be resolved as well