### PR TITLE
New enhancements 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Based on the internal callgraphs of IBM WALA
 
 ##### TAJS
 Based on TAJS
-Some notable fixes are:
+Some notable fixes are :
 by default TAJS stops processing JavaScript files whenever it encounters a console.log
 ( maybe also other native JavaScript calls ); thus to bypass this issue TAJS was modified.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Based on the internal callgraphs of IBM WALA
 
 ##### TAJS
 Based on TAJS
-Some notable fixes are :
+Some notable fixes are:
 by default TAJS stops processing JavaScript files whenever it encounters a console.log
 ( maybe also other native JavaScript calls ); thus to bypass this issue TAJS was modified.
 

--- a/analyzers/dynamic/browser.js
+++ b/analyzers/dynamic/browser.js
@@ -45,7 +45,7 @@ module.exports = function()
 		var url = "http://localhost:" + port + "/" + entry; //"/" + urlDir +
 		
 		return new Promise(async (resolve, reject) => {
-			this.browser = await puppeteer.launch({headless: false}); // await
+			this.browser = await puppeteer.launch({headless: false, executablePath: '/snap/bin/chromium'}); // await
 			this.page = await this.browser.newPage();
 			
 			var consoleLogs = [];

--- a/analyzers/wala.js
+++ b/analyzers/wala.js
@@ -47,7 +47,7 @@ module.exports = function() {
  */
 function walaAnalyzer(file, callback) {
 	var jarFile = path.join(__dirname, 'wala', 'JSONCallGraph.jar');
-	let command = 'java -jar ' + jarFile + ' ' + file;
+	let command = 'java -jar ' + jarFile + ' ' + `${file}`;
 	let settings = {
 		maxBuffer: 1024 * 1000 * 1000,	// 1 GB
 		//timeout: lacunaSettings.ANALYZER_TIMEOUT

--- a/call_graph-edge.js
+++ b/call_graph-edge.js
@@ -1,8 +1,9 @@
 /** represents a caller-callee relationship (directional edge) */
 module.exports = class Edge {
-    constructor(caller, callee, analyzer) {
+    constructor(caller, callee, analyzer, weight) {
         this.caller = caller;
         this.callee = callee;
         this.analyzer = analyzer;
+        this.weight = weight;
     }
 }

--- a/call_graph-node.js
+++ b/call_graph-node.js
@@ -17,12 +17,13 @@ module.exports = class Node {
      * 
      * NOTE multiple edges can exist between the same nodes
      */
-    addEdge(node, analyzer, stripObject) {
-        var edge = new Edge(this, node, analyzer);
+    addEdge(node, analyzer, stripObject, weight) {
+        var edge = new Edge(this, node, analyzer, weight);
         this.edges.push(edge);
 
         var caller = edge.caller;
         var callee = edge.callee;
+        var weight = edge.weight;
 
         if (stripObject) {
             caller = caller.functionData;
@@ -30,7 +31,8 @@ module.exports = class Node {
         }
         return {
             caller,
-            callee
+            callee,
+            weight
         }
     }
 
@@ -73,7 +75,7 @@ module.exports = class Node {
         consideredNodes.push(this);
 
         this.edges.forEach((edge) => {
-            dotty.addEdge(this.__str__(), edge.callee.__str__(), { label: edge.analyzer });
+            dotty.addEdge(this.__str__(), edge.callee.__str__(), { label: `${edge.analyzer}:${edge.weight.toString()}` });
             
             /* Recursively add grand-child relations */
             edge.callee.addToDotify(dotty, consideredNodes); 

--- a/call_graph.js
+++ b/call_graph.js
@@ -37,6 +37,7 @@ module.exports = class CallGraph {
 
         /* Note: these aren't functions, rather the files that call functions */
         this.rootNodes = [];
+        this.edgeWeight = 0;
 
         functions.forEach((functionData) => {
             this.addNode(functionData);
@@ -103,8 +104,16 @@ module.exports = class CallGraph {
         var caller = this.getNode(functionDataCaller);
         var callee = this.getNode(functionDataCallee);
 
+        if (analyzer === "dynamic") {
+            this.edgeWeight = 1.0;
+        } else {
+            this.edgeWeight = 0.5;
+        }
+
+        var edgeWeight = this.edgeWeight;
+
         if (!caller || !callee) { return null; }
-        return caller.addEdge(callee, analyzer, stripObject);
+        return caller.addEdge(callee, analyzer, stripObject, edgeWeight);
     }
 
     /** 

--- a/lacuna.js
+++ b/lacuna.js
@@ -14,7 +14,7 @@ let argv = null;
 try {
     argv = commandLineArgs([
         { name: 'directory', type: String, defaultOption: true }, // obviously has no default option
-        { name: 'analyzer', type: String, multiple: true, alias: 'a' },
+        { name: 'analyzer', type: Object, multiple: false, alias: 'a', defaultValue : '{}' },
 
         { name: 'entry', type: String, alias: 'e' },
         { name: 'olevel', type: Number, alias: 'o' },

--- a/lacunizer.js
+++ b/lacunizer.js
@@ -125,7 +125,7 @@ async function createCompleteCallGraph(runOptions, onCallGraphComplete) {
     var callGraph = new CallGraph(retrieveFunctions(scripts));
 
     /* Part 2: running every analyzer to create edges in the callgraph */
-    var analyzers = retrieveAnalyzers(runOptions.analyzer);
+    var analyzers = retrieveAnalyzers(Object.keys(runOptions.analyzer));
     var analyzerResults = [];
     var analyzersCompleted = {}; // wait for all analyzers to be finished
 


### PR DESCRIPTION
Overview of changes: 
- Added fix for a file path issue with the wala analyzer
- Added chromium executable path to the browser.js file of the dynamic analyzer
- Added callgraph 'weight' value as a part of the constructor in the 'Edge' class
- Added functionality for adding weights to each of the edges in the callgraph
- Expanded the --analyzer CLI argument of Lacuna to accept the CG weight threshold value specified for each analyzer. For doing this, the analzer argument has been changed to accept JSON object instead of string
eg : node lacuna ./example/test/ -a '{"dynamic":"0.5", "static":"0.5"}' -d ./example/test/